### PR TITLE
RGB captures with Epiphan DVI2PCIe Duo

### DIFF
--- a/include/epiphan_controller.h
+++ b/include/epiphan_controller.h
@@ -24,6 +24,16 @@ public:
 public:
 	static EpiphanController& get_instance();
 
+    /**
+     * Start acquisition from specified Epiphan port.
+     *
+     * \param device_ident serial number of requested Epiphan port, followed
+     * by "-i" for capturing in intensity mode (grayscale images), or "-c"
+     * for capturing in colour mode (3-byte packed RGB images). Defaults to
+     * colour mode if nothing or any other suffix specified.
+     * \return true if acquisition has been started, false otherwise
+     * \see determine_colour which will ALWAYS return a valid colour space
+     */
     bool start_acquisition(const char *device_ident);
 
     bool stop_acquisition();
@@ -31,6 +41,8 @@ public:
     bool is_acquiring();
 
     bool get_data(uint8_t *data, uint32_t *width, uint32_t *height);
+
+    static V2U_INT32 determine_colour(const char *device_ident);
 };
 
 static EpiphanController& epiphan_controller = EpiphanController::get_instance();

--- a/include/epiphan_controller.h
+++ b/include/epiphan_controller.h
@@ -42,7 +42,7 @@ public:
 
     bool get_data(uint8_t *data, uint32_t *width, uint32_t *height);
 
-    static V2U_INT32 determine_colour(const char *device_ident);
+    static V2U_INT32 determine_colour(const char *device_ident, char* serial_no);
 };
 
 static EpiphanController& epiphan_controller = EpiphanController::get_instance();

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -29,7 +29,7 @@ EpiphanController& EpiphanController::get_instance()
 }
 
 
-V2U_INT32 determine_colour(const char *device_ident)
+V2U_INT32 EpiphanController::determine_colour(const char *device_ident)
 {
     V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
     std::string device_ident_(device_ident);

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -29,15 +29,26 @@ EpiphanController& EpiphanController::get_instance()
 }
 
 
-V2U_INT32 EpiphanController::determine_colour(const char *device_ident)
+V2U_INT32 EpiphanController::determine_colour(const char *device_ident, char* serial_no)
 {
-    V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
+    V2U_INT32 colour_space = 0;
     std::string device_ident_(device_ident);
     std::string colour_spec = device_ident_.substr(device_ident_.size()-2);
+    size_t serial_no_length = device_ident_.size();
     if (colour_spec.compare("-c") == 0)
+    {
         colour_space = V2U_GRABFRAME_FORMAT_RGB24;
+        serial_no_length -= 2;
+    }
     else if (colour_spec.compare("-i") == 0)
+    {
         colour_space = V2U_GRABFRAME_FORMAT_I420;
+        serial_no_length -= 2;
+    }
+    else
+        colour_space = V2U_GRABFRAME_FORMAT_RGB24;
+
+    strcpy(serial_no, device_ident_.substr(0, serial_no_length).c_str());
     return colour_space;
 }
 
@@ -49,15 +60,16 @@ bool EpiphanController::start_acquisition(const char *device_ident)
 
 	FrmGrab_Init();
 
-	frame_grabber = FrmGrab_Open(device_ident);
+    char serial_no[100];
+    flags |= determine_colour(device_ident, serial_no);
+
+	frame_grabber = FrmGrab_Open(serial_no);
 
 	if (frame_grabber == NULL)
 	{
 		std::cerr << "Could not open " << device_ident << std::endl;
 		return false;
 	}
-
-	flags |= determine_colour(device_ident);
 
 	// TODO: set ROI more intelligently
 	roi.x = 320;

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -1,6 +1,7 @@
 #include "epiphan_controller.h"
 
 #include <iostream>
+#include <string>
 
 #ifdef USE_EPIPHAN
 
@@ -28,6 +29,19 @@ EpiphanController& EpiphanController::get_instance()
 }
 
 
+V2U_INT32 determine_colour(const char *device_ident)
+{
+    V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
+    std::string device_ident_(device_ident);
+    std::string colour_spec = device_ident_.substr(device_ident_.size()-2);
+    if (colour_spec.compare("-c"))
+        colour_space = V2U_GRABFRAME_FORMAT_RGB24;
+    else if (colour_spec.compare("-i"))
+        colour_space = V2U_GRABFRAME_FORMAT_I420;
+    return colour_space;
+}
+
+
 bool EpiphanController::start_acquisition(const char *device_ident)
 {
 	if (is_acquiring())
@@ -43,8 +57,7 @@ bool EpiphanController::start_acquisition(const char *device_ident)
 		return false;
 	}
 
-	V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
-	flags |= colour_space;
+	flags |= determine_colour(device_ident);
 
 	// TODO: set ROI more intelligently
 	roi.x = 320;

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -99,8 +99,12 @@ bool EpiphanController::get_data(uint8_t *data, uint32_t *width, uint32_t *heigh
 	if (buffer == NULL)
 		return false;
 
-	size_t length_of_y = buffer->crop.width * buffer->crop.height;
-	memcpy(data, buffer->pixbuf, length_of_y);
+    size_t relevant_data_length = 0;
+    if (flags & V2U_GRABFRAME_FORMAT_I420)
+        relevant_data_length = buffer->crop.width * buffer->crop.height;
+    else if (flags & V2U_GRABFRAME_FORMAT_RGB24)
+        relevant_data_length = buffer->imagelen;
+	memcpy(data, buffer->pixbuf, relevant_data_length);
 	*width = buffer->crop.width;
 	*height = buffer->crop.height;
 

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -34,9 +34,9 @@ V2U_INT32 EpiphanController::determine_colour(const char *device_ident)
     V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
     std::string device_ident_(device_ident);
     std::string colour_spec = device_ident_.substr(device_ident_.size()-2);
-    if (colour_spec.compare("-c"))
+    if (colour_spec.compare("-c") == 0)
         colour_space = V2U_GRABFRAME_FORMAT_RGB24;
-    else if (colour_spec.compare("-i"))
+    else if (colour_spec.compare("-i") == 0)
         colour_space = V2U_GRABFRAME_FORMAT_I420;
     return colour_space;
 }

--- a/src/epiphan_controller.cpp
+++ b/src/epiphan_controller.cpp
@@ -43,7 +43,7 @@ bool EpiphanController::start_acquisition(const char *device_ident)
 		return false;
 	}
 
-	V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_I420;
+	V2U_INT32 colour_space = V2U_GRABFRAME_FORMAT_RGB24;
 	flags |= colour_space;
 
 	// TODO: set ROI more intelligently


### PR DESCRIPTION
Closes #35 

Captures from Epiphan default to the packed 24-bit RGB format now. However the capture format can be explicitly specified with a trailing:

- `-i` for intensity (grayscale)
- `-c` for colour (RGB)

If no capture format explicitly specified, then RGB is used.